### PR TITLE
[FIX] Use stack based delimiter stack instead of pointer based delimiter stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 CC = gcc
 
-CFLAGS += -Wall -Werror -Wextra -pedantic --std=c11 -I$(INC)
+DEFS   += -D_POSIX_C_SOURCE=200809L
+CFLAGS += -Wall -Werror -Wextra -pedantic --std=c11 -I$(INC) $(DEFS)
 
 INC	  = src/include
-SRC  := src/main.c src/lexer.c
+SRC  := $(wildcard src/*.c)
 OBJS := billion
 all: $(OBJS)
 

--- a/src/file.c
+++ b/src/file.c
@@ -1,0 +1,41 @@
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "billion.h"
+
+#ifndef _POSIX_C_SOURCE
+    #define _POSIX_C_SOURCE 1
+#endif
+
+static char* get_filename(FILE *fp)
+{
+    int fd;
+    char fd_path[255];
+    char *filename = malloc(sizeof(char) * 255);
+    ssize_t n;
+
+    fd = fileno(fp);
+    sprintf(fd_path, "/proc/self/fd/%d", fd);
+    n = readlink(fd_path, filename, 255);
+    if (n < 0)
+        return NULL;
+    filename[n] = '\0';
+    return filename;
+}
+
+void free_file_info(FileInfo *fi)
+{
+    free((void*)fi->filename);
+    free(fi);
+}
+
+FileInfo* new_file_info(FILE *fp, int curr_line)
+{
+    FileInfo *fi = malloc(sizeof(FileInfo));
+    fi->filename = get_filename(fp);
+    fi->curr_line = curr_line;
+
+    return fi;
+}

--- a/src/include/billion.h
+++ b/src/include/billion.h
@@ -1,4 +1,9 @@
 #include "ast.h"
+#include "file.h"
 #include "lexer.h"
 #include "parser.h"
 #include "utilities.h"
+
+#ifndef _POSIX_C_SOURCE
+    #define _POSIX_C_SOURCE 1
+#endif

--- a/src/include/file.h
+++ b/src/include/file.h
@@ -1,0 +1,10 @@
+#include <stdio.h>
+
+typedef struct {
+    const char *filename;
+    const char *encoding;
+    int        curr_line;
+} FileInfo;
+
+void      free_file_info(FileInfo *fi);
+FileInfo* new_file_info(FILE *fp, int curr_line);

--- a/src/include/lexer.h
+++ b/src/include/lexer.h
@@ -30,4 +30,4 @@ typedef struct {
 static const Token empty_tok;
 
 void free_tokens(Token *tokens);
-Token* lex(char *line, int lineno);
+Token* lex(FileInfo *fi, char *line);

--- a/src/include/lexer.h
+++ b/src/include/lexer.h
@@ -26,5 +26,8 @@ typedef struct {
     char       *value;
 } Token;
 
+// Token to reset delimiters
+static const Token empty_tok;
+
 void free_tokens(Token *tokens);
 Token* lex(char *line, int lineno);

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -5,7 +5,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "lexer.h"
+#include "billion.h"
+
 
 static char* initialize_buffer()
 {
@@ -20,7 +21,7 @@ static void reset_buffer(char buff[], int *counter)
     *counter = 0;
 }
 
-static Token new_tok(int kind, char *buff, int counter, int lineno, int pos)
+static Token new_tok(char *buff, int kind, int counter, int lineno, int pos)
 {
     Token token;
     token.kind = kind;
@@ -43,7 +44,7 @@ void free_tokens(Token *tokens)
 }
 
 // This function lexes a line into an array of tokens, with type and value.
-Token* lex(char *line, int lineno)
+Token* lex(FileInfo *fi, char *line)
 {
     Token *tokens = malloc(sizeof(Token) * LEX_CAP);
     
@@ -79,7 +80,7 @@ Token* lex(char *line, int lineno)
             buff[counter++] = line[i];
             // see if identifier is a keyword, and reset it afterwards
             if (strcmp(buff, "exposed") == 0) {
-                Token token = new_tok(TOK_PRINT, buff, counter, lineno, i); 
+                Token token = new_tok(buff, TOK_PRINT, counter, fi->curr_line, i); 
                 reset_buffer(buff, &counter);
                 tokens[token_counter++] = token;
             }
@@ -90,14 +91,16 @@ Token* lex(char *line, int lineno)
         switch (line[i]) {
             case ';': {
                 buff[counter++] = line[i];
-                Token token = new_tok(TOK_END_EXPR_DELIM, buff, counter, lineno,
-                                      i);
+                Token token = new_tok(buff, TOK_END_EXPR_DELIM, counter, 
+                                      fi->curr_line, i);
                 reset_buffer(buff, &counter);
                 tokens[token_counter++] = token;
                 
                 if (delim_index != 0) {
-                    fprintf(stderr, "[ERROR] line:%d:%d - Delimiter not closed\n",
-                            lineno, delim_stack->pos);
+                    fprintf(stderr, "[ERROR] %s:%d:%d - Delimiter not closed\n",
+                            fi->filename,
+                            delim_stack[delim_index].lineno,
+                            delim_stack[delim_index].pos+1);
                     free_tokens(tokens);
                     return NULL;
                 }
@@ -105,8 +108,8 @@ Token* lex(char *line, int lineno)
             }
             case '(': {
                 buff[counter++] = line[i];
-                Token token = new_tok(TOK_PAREN_OPEN_DELIM, buff, counter,
-                                      lineno, i);
+                Token token = new_tok(buff, TOK_PAREN_OPEN_DELIM, counter,
+                                      fi->curr_line, i);
                 reset_buffer(buff, &counter);
                 tokens[token_counter++] = token;
                 delim_stack[delim_index++] = token;
@@ -115,14 +118,15 @@ Token* lex(char *line, int lineno)
             case ')': {
                 buff[counter++] = line[i];
                 if (strcmp(delim_stack[delim_index-1].value, "(") != 0) {
-                    fprintf(stderr, "[ERROR] line:%d:%d - Expected to match "
-                            "delimiters\n", delim_stack[delim_index-1].lineno, 
+                    fprintf(stderr, "[ERROR] %s:%d:%d - Expected to match "
+                            "delimiters\n", fi->filename,
+                            delim_stack[delim_index-1].lineno, 
                             delim_stack[delim_index-1].pos);
                     free_tokens(tokens);
                     return NULL;
                 }
-                Token token = new_tok(TOK_PAREN_CLOSE_DELIM, buff, counter, 
-                                      lineno, i);
+                Token token = new_tok(buff, TOK_PAREN_CLOSE_DELIM, counter, 
+                                      fi->curr_line, i);
                 reset_buffer(buff, &counter);
                 tokens[token_counter++] = token;
                 delim_stack[--delim_index] = empty_tok;
@@ -130,7 +134,8 @@ Token* lex(char *line, int lineno)
             }
             case '"': {
                 if (is_string) {
-                    Token token = new_tok(TOK_STRING, buff, counter, lineno, i);
+                    Token token = new_tok(buff, TOK_STRING, counter,
+                                          fi->curr_line, i);
                     reset_buffer(buff, &counter);
                     tokens[token_counter++] = token;
                 }

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include "billion.h"
 
 int main (int argc, char *argv[])
@@ -19,11 +20,16 @@ int main (int argc, char *argv[])
         return 1;
     }
 
+    FileInfo *file_info = new_file_info(file, lineno); 
+
     // Lexical analysis
     while(fgets(line, sizeof(line), file)) {
-        Token *tokens = lex(line, ++lineno); 
+        file_info->curr_line++;
+        Token *tokens = lex(file_info, line); 
         if (tokens == NULL) {
             fprintf(stderr, "[ERROR] Lexing error, exiting...\n");
+            free_file_info(file_info);
+            fclose(file);
             return 1;
         }
         
@@ -40,6 +46,7 @@ int main (int argc, char *argv[])
         free_tokens(tokens);
     }
 
+    free_file_info(file_info);
     fclose(file);
     return 0;
 }


### PR DESCRIPTION
This fixes #5. Basically I rewrote the delimiter stack to use a local stack instead of a malloc'd stack. So every time a delimiter is opened, a copy of the token struct is given to the stack instead of its address. This is done to avoid getting the same address that `new_tok` function returns.

I might have fucked up in how I implemented this with dynamic allocation. For now, I'll just leave a fixed size stack of tokens for delimiters. When I consider using functional programming for this language, I might consider fixing this properly.